### PR TITLE
Add STOP instruction to terminate payload execution

### DIFF
--- a/rowhammer_tester/gateware/payload_executor.py
+++ b/rowhammer_tester/gateware/payload_executor.py
@@ -143,6 +143,9 @@ class Encoder:
             ]
         else:
             assert kwargs['timeslice'] != 0, 'Timeslice for instructions other than NOOP should be > 0'
+            no_address = [OpCode.REF]  # PRE requires bank address
+            assert 'address' in kwargs or op_code in no_address, \
+                '{} instruction requires `address`'.format(op_code.name)
             parts = [
                 (Decoder.OP_CODE,   op_code),
                 (Decoder.TIMESLICE, kwargs['timeslice']),

--- a/rowhammer_tester/scripts/rowhammer.py
+++ b/rowhammer_tester/scripts/rowhammer.py
@@ -40,26 +40,26 @@ def generate_row_hammer_payload(*,
 
     refreshes = 0
     for outer_idx in range(n_loops):
-        local_refreshes = 1;
-        payload.append(encoder(refresh_op, timeslice=trfc - 1))
+        local_refreshes = 1
+        payload.append(encoder(refresh_op, timeslice=trfc))
         accum = trfc
         for row in row_sequence:
             if accum + tras + trp > trefi:
-                payload.append(encoder(refresh_op, timeslice=trfc - 1))
+                payload.append(encoder(refresh_op, timeslice=trfc))
                 # Invariant: time between the beginning of two refreshes
                 # is is less than tREFI.
                 accum = trfc
                 local_refreshes += 1
             accum += tras + trp
             payload.extend([
-                encoder(OpCode.ACT,  timeslice=tras - 1, address=encoder.address(bank=bank, row=row)),
-                encoder(OpCode.PRE,  timeslice=trp - 1, address=encoder.address(col=1 << 10)),  # all
+                encoder(OpCode.ACT,  timeslice=tras, address=encoder.address(bank=bank, row=row)),
+                encoder(OpCode.PRE,  timeslice=trp, address=encoder.address(col=1 << 10)),  # all
             ])
         if outer_idx == 0:
             loop_count = ceil(read_count) % (count_max + 1)
         else:
-            loop_count = count_max;
-        refreshes += local_refreshes * loop_count;
+            loop_count = count_max
+        refreshes += local_refreshes * loop_count
         jump_target = 2*len(row_sequence) + 1
         payload.append(encoder(OpCode.LOOP, count=loop_count, jump=jump_target))
 

--- a/rowhammer_tester/targets/common.py
+++ b/rowhammer_tester/targets/common.py
@@ -404,10 +404,11 @@ def configure_generated_files(builder, args, target_name):
     with open(os.path.join(builder.output_dir, 'defs.csv'), 'w', newline='') as f:
         writer = csv.writer(f)
         writer.writerows([
-            ('TARGET',      target_name),
-            ('IP_ADDRESS',  args.ip_address),
-            ('MAC_ADDRESS', args.mac_address),
-            ('UDP_PORT',    args.udp_port),
+            ('TARGET',       target_name),
+            ('IP_ADDRESS',   args.ip_address),
+            ('MAC_ADDRESS',  args.mac_address),
+            ('UDP_PORT',     args.udp_port),
+            ('SYS_CLK_FREQ', args.sys_clk_freq),
         ])
     # LiteDRAM settings (controller, phy, geom, timing)
     with open(os.path.join(builder.output_dir, 'litedram_settings.json'), 'w') as f:

--- a/tests/test_payload_executor.py
+++ b/tests/test_payload_executor.py
@@ -374,75 +374,58 @@ class TestPayloadExecutor(unittest.TestCase):
 
         run_simulation(dut, [generator(dut), *dut.get_generators()], **kwargs)
 
+    def assert_history(self, history, op_codes):
+        self.assertEqual(len(history), len(op_codes))
+        for entry, op in zip(history, op_codes):
+            self.assertEqual(entry.cmd.op_code, op)
+
     def test_timeslice_0_noop_legal(self):
+        # Check that encoding NOOP with timeslice=0 is legal (STOP instruction)
         Encoder(bankbits=3)(OpCode.NOOP, timeslice=0)
 
     def test_timeslice_0_other_illegal(self):
+        # Check that encoding DFI instructions with timeslice=0 is results in an error
         with self.assertRaises(AssertionError):
             Encoder(bankbits=3)(OpCode.ACT, timeslice=0)
 
     def test_payload_simple(self):
+        # Check that DFI instuctions in a simple payload are sent in correct order
         encoder = Encoder(bankbits=3)
         payload = [
             encoder(OpCode.ACT,  timeslice=10, address=encoder.address(bank=1, row=100)),
-            encoder(OpCode.READ, timeslice=10, address=encoder.address(bank=1, col=13)),
-            encoder(OpCode.READ, timeslice=30, address=encoder.address(bank=1, col=20)),
-            encoder(OpCode.READ, timeslice=30, address=encoder.address(bank=1, col=20)),
-            encoder(OpCode.READ, timeslice=30, address=encoder.address(bank=1, col=20)),
+            encoder(OpCode.READ, timeslice=3,  address=encoder.address(bank=1, col=13)),
             encoder(OpCode.PRE,  timeslice=10, address=encoder.address(bank=1)),
+            encoder(OpCode.REF,  timeslice=15),
         ]
 
         dut = PayloadExecutorDUT(payload)
         self.run_payload(dut)
 
         # compare DFI history to what payload should yield
-        op_codes = [OpCode.ACT] + 4*[OpCode.READ] + [OpCode.PRE]
-        self.assertEqual(len(dut.dfi_history), len(op_codes))
-        for entry, op in zip(dut.dfi_history, op_codes):
-            self.assertEqual(entry.cmd.op_code, op)
+        op_codes = [OpCode.ACT, OpCode.READ, OpCode.PRE, OpCode.REF]
+        self.assert_history(dut.dfi_history, op_codes)
 
     def test_payload_loop(self):
+        # Check that LOOP is executed correctly
         encoder = Encoder(bankbits=3)
         payload = [
-            encoder(OpCode.NOOP, timeslice=50),
-
-            encoder(OpCode.ACT,  timeslice=10, address=encoder.address(bank=1, row=100)),
-            encoder(OpCode.READ, timeslice=10, address=encoder.address(bank=1, col=13)),
-            encoder(OpCode.READ, timeslice=30, address=encoder.address(bank=1, col=20)),
-            encoder(OpCode.PRE,  timeslice=10, address=encoder.address(bank=1)),
-
             encoder(OpCode.ACT,  timeslice=10, address=encoder.address(bank=0, row=100)),
             encoder(OpCode.READ, timeslice=30, address=encoder.address(bank=0, col=200)),
             encoder(OpCode.LOOP, count=8 - 1, jump=1),  # to READ col=200
-            encoder(OpCode.READ, timeslice=30, address=encoder.address(bank=0, col=208)),
-            encoder(OpCode.READ, timeslice=30, address=encoder.address(bank=0, col=216)),
-            encoder(OpCode.READ, timeslice=30, address=encoder.address(bank=0, col=224)),
-            encoder(OpCode.READ, timeslice=30, address=encoder.address(bank=0, col=232)),
-            encoder(OpCode.READ, timeslice=30, address=encoder.address(bank=0, col=240)),
-            encoder(OpCode.READ, timeslice=30, address=encoder.address(bank=0, col=248)),
-            encoder(OpCode.READ, timeslice=30, address=encoder.address(bank=0, col=256)),
-            encoder(OpCode.READ, timeslice=30, address=encoder.address(bank=0, col=264)),
-            encoder(OpCode.READ, timeslice=30, address=encoder.address(bank=0, col=300 | (1 << 10))),  # auto precharge
-
-            encoder(OpCode.ACT,  timeslice=60, address=encoder.address(bank=2, row=150)),
-
-            encoder(OpCode.PRE,  timeslice=10, address=encoder.address(col=1 << 10)),  # all
+            encoder(OpCode.PRE,  timeslice=40, address=encoder.address(bank=0)),
             encoder(OpCode.REF,  timeslice=50),
             encoder(OpCode.REF,  timeslice=50),
-
-            encoder(OpCode.NOOP, timeslice=50),
+            encoder(OpCode.LOOP, count=5 - 1, jump=2),  # to first REF
         ]
 
         dut = PayloadExecutorDUT(payload)
         self.run_payload(dut)
 
-        op_codes = [OpCode.ACT] + 2*[OpCode.READ] + [OpCode.PRE] \
-            + [OpCode.ACT] + (8+9)*[OpCode.READ] + [OpCode.ACT] + [OpCode.PRE] + 2*[OpCode.REF]
-        self.assertEqual(len(dut.dfi_history), len(op_codes))
-        for entry, op in zip(dut.dfi_history, op_codes):
-            self.assertEqual(entry.cmd.op_code, op)
+        op_codes = [OpCode.ACT] + 8*[OpCode.READ] + [OpCode.PRE] + 5*2*[OpCode.REF]
+        self.assert_history(dut.dfi_history, op_codes)
 
     def test_stop(self):
+        # Check that STOP terminates execution
         encoder = Encoder(bankbits=3)
         payload = [
             encoder(OpCode.ACT,  timeslice=10, address=encoder.address(bank=1, row=100)),
@@ -458,29 +441,77 @@ class TestPayloadExecutor(unittest.TestCase):
         self.run_payload(dut)
 
         op_codes = [OpCode.ACT] + 2*[OpCode.READ]
-        self.assertEqual(len(dut.dfi_history), len(op_codes))
-        for entry, op in zip(dut.dfi_history, op_codes):
-            self.assertEqual(entry.cmd.op_code, op)
+        self.assert_history(dut.dfi_history, op_codes)
 
-    def test_timeslice_cycles(self):
+    def test_execution_cycles_with_stop(self):
+        # Check that execution time is correct with STOP instruction
         encoder = Encoder(bankbits=3)
         payload = [
             encoder(OpCode.ACT,  timeslice=1, address=encoder.address(bank=1, row=100)),
             encoder(OpCode.READ, timeslice=1, address=encoder.address(bank=1, col=20)),
             encoder(OpCode.PRE,  timeslice=1, address=encoder.address(bank=1)),
-            encoder(OpCode.NOOP, timeslice=1),  # takes 1 cycle
             encoder(OpCode.NOOP, timeslice=0),  # STOP, takes 1 cycle
+            encoder(OpCode.ACT,  timeslice=10, address=encoder.address(bank=1, row=100)),
         ]
 
         dut = PayloadExecutorDUT(payload)
         self.run_payload(dut)
 
         op_codes = [OpCode.ACT, OpCode.READ, OpCode.PRE]
-        self.assertEqual(len(dut.dfi_history), len(op_codes))
-        for entry, op in zip(dut.dfi_history, op_codes):
-            self.assertEqual(entry.cmd.op_code, op)
+        self.assert_history(dut.dfi_history, op_codes)
+        self.assertEqual(dut.cycles, 4)
 
-        self.assertEqual(dut.cycles, 5)
+    def test_execution_cycles_default_stop(self):
+        # Check execution time with no explicit STOP, but rest of memory is filled with zeros (=STOP)
+        encoder = Encoder(bankbits=3)
+        payload = [
+            encoder(OpCode.ACT,  timeslice=1, address=encoder.address(bank=1, row=100)),
+            encoder(OpCode.READ, timeslice=1, address=encoder.address(bank=1, col=20)),
+            encoder(OpCode.PRE,  timeslice=1, address=encoder.address(bank=1)),
+        ]
+
+        dut = PayloadExecutorDUT(payload)
+        self.run_payload(dut)
+
+        op_codes = [OpCode.ACT, OpCode.READ, OpCode.PRE]
+        self.assert_history(dut.dfi_history, op_codes)
+        self.assertEqual(dut.cycles, 4)
+
+    def test_execution_cycles_no_stop(self):
+        # Check execution time when there is no STOP instruction (rest of memory filled with NOOPs)
+        encoder = Encoder(bankbits=3)
+        payload = [
+            encoder(OpCode.ACT,  timeslice=1, address=encoder.address(bank=1, row=100)),
+            encoder(OpCode.READ, timeslice=1, address=encoder.address(bank=1, col=20)),
+            encoder(OpCode.PRE,  timeslice=1, address=encoder.address(bank=1)),
+        ]
+
+        depth = 16
+        payload += [encoder(OpCode.NOOP, timeslice=1)] * (depth - len(payload))
+        dut = PayloadExecutorDUT(payload, payload_depth=depth)
+        self.run_payload(dut)
+
+        op_codes = [OpCode.ACT, OpCode.READ, OpCode.PRE]
+        self.assert_history(dut.dfi_history, op_codes)
+        self.assertEqual(dut.cycles, depth)
+
+    def test_execution_cycles_longer(self):
+        # Check execution time with timeslices longer than 1
+        encoder = Encoder(bankbits=3)
+        payload = [
+            encoder(OpCode.ACT,  timeslice=7,  address=encoder.address(bank=1, row=100)),
+            encoder(OpCode.READ, timeslice=3,  address=encoder.address(bank=1, col=20)),
+            encoder(OpCode.PRE,  timeslice=5,  address=encoder.address(bank=1)),
+            encoder(OpCode.REF,  timeslice=10, address=encoder.address(col=1 << 10)),  # all banks
+            encoder(OpCode.NOOP, timeslice=0),  # STOP
+        ]
+
+        dut = PayloadExecutorDUT(payload)
+        self.run_payload(dut)
+
+        op_codes = [OpCode.ACT, OpCode.READ, OpCode.PRE, OpCode.REF]
+        self.assert_history(dut.dfi_history, op_codes)
+        self.assertEqual(dut.cycles, 7 + 3 + 5 + 10 + 1)
 
 # Interactive tests --------------------------------------------------------------------------------
 

--- a/tests/test_payload_executor.py
+++ b/tests/test_payload_executor.py
@@ -502,19 +502,19 @@ class TestPayloadExecutor(unittest.TestCase):
         # Check execution time with timeslices longer than 1
         encoder = Encoder(bankbits=3)
         payload = [
-            encoder(OpCode.ACT,  timeslice=7,  address=encoder.address(bank=1, row=100)),
-            encoder(OpCode.READ, timeslice=3,  address=encoder.address(bank=1, col=20)),
-            encoder(OpCode.PRE,  timeslice=5,  address=encoder.address(bank=1)),
-            encoder(OpCode.REF,  timeslice=10),
-            encoder(OpCode.NOOP, timeslice=0),  # STOP
+            encoder.I(OpCode.ACT,  timeslice=7,  address=encoder.address(bank=1, row=100)),
+            encoder.I(OpCode.READ, timeslice=3,  address=encoder.address(bank=1, col=20)),
+            encoder.I(OpCode.PRE,  timeslice=5,  address=encoder.address(bank=1)),
+            encoder.I(OpCode.REF,  timeslice=10),
+            encoder.I(OpCode.NOOP, timeslice=0),  # STOP
         ]
 
-        dut = PayloadExecutorDUT(payload)
+        dut = PayloadExecutorDUT(encoder(payload))
         self.run_payload(dut)
 
         op_codes = [OpCode.ACT, OpCode.READ, OpCode.PRE, OpCode.REF]
         self.assert_history(dut.dfi_history, op_codes)
-        self.assertEqual(dut.cycles, 7 + 3 + 5 + 10 + 1)
+        self.assertEqual(dut.cycles, sum(max(1, i.timeslice) for i in payload))
 
 # Interactive tests --------------------------------------------------------------------------------
 

--- a/tests/test_payload_executor.py
+++ b/tests/test_payload_executor.py
@@ -122,7 +122,10 @@ class TestDecoder(unittest.TestCase):
             encoder = Encoder(bankbits=3)
 
             for op in OpCode:
-                kwargs = dict(count=1, jump=1) if op == OpCode.LOOP else dict(timeslice=1)
+                kwargs = {
+                    OpCode.LOOP: dict(count=1, jump=1),
+                    OpCode.NOOP: dict(timeslice=1),
+                }.get(op, dict(timeslice=1, address=0))  # others
                 yield dut.instruction.eq(encoder(op, **kwargs))
                 yield
                 self.assertEqual((yield dut.decoder.op_code), op)
@@ -171,7 +174,7 @@ class TestDecoder(unittest.TestCase):
             encoder = Encoder(bankbits=3)
 
             timeslice_max = 2**Decoder.TIMESLICE - 1
-            yield dut.instruction.eq(encoder(OpCode.ACT, timeslice=timeslice_max))
+            yield dut.instruction.eq(encoder(OpCode.ACT, timeslice=timeslice_max, address=0))
             yield
             self.assertEqual((yield dut.decoder.timeslice), timeslice_max)
 
@@ -502,7 +505,7 @@ class TestPayloadExecutor(unittest.TestCase):
             encoder(OpCode.ACT,  timeslice=7,  address=encoder.address(bank=1, row=100)),
             encoder(OpCode.READ, timeslice=3,  address=encoder.address(bank=1, col=20)),
             encoder(OpCode.PRE,  timeslice=5,  address=encoder.address(bank=1)),
-            encoder(OpCode.REF,  timeslice=10, address=encoder.address(col=1 << 10)),  # all banks
+            encoder(OpCode.REF,  timeslice=10),
             encoder(OpCode.NOOP, timeslice=0),  # STOP
         ]
 


### PR DESCRIPTION
Closes https://github.com/antmicro/litex-rowhammer-tester/issues/32.

This PR makes NOOP with `timeslice=0` be interpreted as STOP. Execution of STOP takes 1 cycle and terminates execution of payload. Timeslice is now interpreted as the exact number of cycles of instruction execution. It is invalid to use DFI instructions with timeslice=0. Generation of row-hammer payload has been updated to use the new timeslice interpretation and add STOP instruction.

If the [Encoder class](https://github.com/antmicro/litex-rowhammer-tester/blob/61b359ce2ada2223c534a2dbc6f297eae4b15abe/rowhammer_tester/gateware/payload_executor.py#L126) is used to define the payload, it will prevent such errors. It however does not perform full payload verification and it would be good to run the actual payload verifier before payload is transferred. The payload verifier would now need to use the new `timeslice` interpretation and support STOP.

We can merge it if it looks ok to you @sqazi. 