### PR TITLE
Synchronize mode transition to memory controller's REF command

### DIFF
--- a/rowhammer_tester/targets/common.py
+++ b/rowhammer_tester/targets/common.py
@@ -32,7 +32,7 @@ from liteeth.frontend.etherbone import LiteEthEtherbone
 
 from rowhammer_tester.gateware.bist import Reader, Writer, PatternMemory
 from rowhammer_tester.gateware.rowhammer import RowHammerDMA
-from rowhammer_tester.gateware.payload_executor import PayloadExecutor, DFISwitch, CERefresher
+from rowhammer_tester.gateware.payload_executor import PayloadExecutor, DFISwitch, SyncableRefresher
 
 # SoC ----------------------------------------------------------------------------------------------
 
@@ -160,7 +160,7 @@ class RowHammerSoC(SoCCore):
         controller_settings = ControllerSettings()
         controller_settings.with_auto_precharge = True
         controller_settings.with_refresh = self.controller_settings.refresh.storage
-        controller_settings.refresh_cls = CERefresher
+        controller_settings.refresh_cls = SyncableRefresher
 
         self.add_sdram("sdram",
             phy                     = self.ddrphy,
@@ -262,9 +262,9 @@ class RowHammerSoC(SoCCore):
                 colorer('Scratchpad memory'), colorer(scratchpad_depth), colorer(scratchpad_width)))
 
             dfi_switch = DFISwitch(
-                with_refresh = self.sdram.controller.settings.with_refresh,
-                dfii         = self.sdram.dfii,
-                refresher_ce = self.sdram.controller.refresher.ce,
+                with_refresh    = self.sdram.controller.settings.with_refresh,
+                dfii            = self.sdram.dfii,
+                refresher_reset = self.sdram.controller.refresher.reset,
             )
             self.submodules += dfi_switch
 

--- a/rowhammer_tester/targets/common.py
+++ b/rowhammer_tester/targets/common.py
@@ -32,7 +32,7 @@ from liteeth.frontend.etherbone import LiteEthEtherbone
 
 from rowhammer_tester.gateware.bist import Reader, Writer, PatternMemory
 from rowhammer_tester.gateware.rowhammer import RowHammerDMA
-from rowhammer_tester.gateware.payload_executor import PayloadExecutor
+from rowhammer_tester.gateware.payload_executor import PayloadExecutor, DFISwitch, CERefresher
 
 # SoC ----------------------------------------------------------------------------------------------
 
@@ -160,6 +160,7 @@ class RowHammerSoC(SoCCore):
         controller_settings = ControllerSettings()
         controller_settings.with_auto_precharge = True
         controller_settings.with_refresh = self.controller_settings.refresh.storage
+        controller_settings.refresh_cls = CERefresher
 
         self.add_sdram("sdram",
             phy                     = self.ddrphy,
@@ -260,11 +261,17 @@ class RowHammerSoC(SoCCore):
             self.logger.info('{}: Length: {}, Data Width: {}-bit'.format(
                 colorer('Scratchpad memory'), colorer(scratchpad_depth), colorer(scratchpad_width)))
 
+            dfi_switch = DFISwitch(
+                with_refresh = self.sdram.controller.settings.with_refresh,
+                dfii         = self.sdram.dfii,
+                refresher_ce = self.sdram.controller.refresher.ce,
+            )
+            self.submodules += dfi_switch
+
             self.submodules.payload_executor = PayloadExecutor(
                 mem_payload    = payload_mem,
                 mem_scratchpad = scratchpad_mem,
-                dfi            = self.sdram.dfii.ext_dfi,
-                dfi_sel        = self.sdram.dfii.ext_dfi_sel,
+                dfi_switch     = dfi_switch,
                 nranks         = self.sdram.controller.settings.phy.nranks,
                 bankbits       = self.sdram.controller.settings.geom.bankbits,
                 rowbits        = self.sdram.controller.settings.geom.rowbits,


### PR DESCRIPTION
This PR improves the moment of transition to payload execution and back. 

Now, after writing to the `start` CSR, Payload Executor will not immediately disconnect the memory controller, but will wait for a REFRESH command. This way the start of payload execution is well-defined in relation to DRAM timings. The first payload instruction is executed 2 clock cycles after the REF command, so the first payload instruction should be a NOOP with `timeslice=tRFC-2`. On the transition back, the refresh timer in memory controller gets reset, so first REF will be issued tREFI after finishing payload execution. I updated row-hammer payload generation in `rowhammer.py` to include the additional NOOP and REF.

Please take a look at this @sqazi and say if this is the way we want the transition to work.