### PR TITLE
Add support for using SPD EEPROM data

### DIFF
--- a/doc/development.rst
+++ b/doc/development.rst
@@ -1,6 +1,8 @@
 Development
 ===========
 
+.. _adding-new-dram-modules:
+
 Adding new DRAM modules
 -----------------------
 
@@ -17,3 +19,54 @@ To make developement more convenient, modules can be added in litex-rowhammer-te
    After ensuring that the module works correctly, a Pull Request to LiteDRAM should be created to add support for the module.
 
 To add a new module definition, use the existing ones as a reference. New module class should derive from ``SDRAMModule`` (or the helper classes, e.g. ``DDR4Module``\ ). Timing/geometry values for a module have to be obtained from the revelant DRAM module's datasheet. The timings in classes deriving from ``SDRAMModule`` are specified in nanoseconds. The timing value can also be specified as a 2-element tuple ``(ck, ns)``\ , in which case ``ck`` is the number of clock cycles and ``ns`` is the number of nanoseconds (and can be ``None``\ ). The highest of the resulting timing values will be used.
+
+SPD EEPROM
+----------
+
+On boards that use DIMM/SO-DIMM modules (e.g. ZCU104) it is possible to read the contents of the DRAM modules's `SPD EEPROM memory <https://en.wikipedia.org/wiki/Serial_presence_detect>`_.
+SPD contains several essential module parameters that the memory controller needs in order to use the DRAM module.
+SPD EEPROM can be read over I2C bus.
+
+Reading SPD EEPROM
+^^^^^^^^^^^^^^^^^^
+
+To read the SPD memory use the script ``rowhammer_tester/scripts/spd_eeprom.py``.
+First prepare the environment as described in :ref:`controlling-the-board`.
+Then use the following command to read the contents of SPD EEPROM and save it to a file, for example:
+
+.. code:: sh
+
+   python rowhammer_tester/scripts/spd_eeprom.py read MTA4ATF51264HZ-3G2J1.bin
+
+The contents of the file can then be used to get DRAM module parameters.
+Use the following command to examine the parameters:
+
+.. code:: sh
+
+   python rowhammer_tester/scripts/spd_eeprom.py show MTA4ATF51264HZ-3G2J1.bin 125e6
+
+Note that system clock frequency must be passed as an argument to determine timing values in controller clock cycles.
+
+Using SPD data
+^^^^^^^^^^^^^^
+
+LiteDRAM does not yet allow to specify timing parameters at runtime.
+In order to use the new parameters it is necessary to rebuild the bitstream using the information extracted from the SPD memory.
+To do this use the ``--from-spd`` command line argument, for example:
+
+.. code:: sh
+
+   make ARGS="--from-spd MTA4ATF51264HZ-3G2J1.bin" build
+
+Then just load the new bitstream.
+
+.. note::
+
+   Not supporting DRAM parameter configuration in runtime reduces resource usage of the LiteDRAM controller
+   and is enough for most use cases. In the future runtime configuration is planned as optional feature.
+
+Adding module configuration
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+After verifying that given module configuration stored in SPD works correctly it can be used to define module in Python.
+To do that use the output of ``spd_eeprom.py show`` to add a new module as described in :ref:`adding-new-dram-modules`

--- a/doc/dram_modules.rst
+++ b/doc/dram_modules.rst
@@ -1,12 +1,17 @@
-Development
-===========
-
-.. _adding-new-dram-modules:
-
-Adding new DRAM modules
------------------------
+DRAM modules
+============
 
 When building one of the targets in `rowhammer_tester/targets <https://github.com/antmicro/litex-rowhammer-tester/tree/master/rowhammer_tester/targets>`_, a custom DRAM module can be specified using the ``--module`` argument. To find the default modules for each target, check the output of ``--help``.
+
+.. note::
+
+   Specifying different DRAM module makes most sense on boards that allow to easily replace the DRAM module,
+   such as on ZCU104. On other boards it would be necessary to desolder the DRAM chip and solder a new one.
+
+.. _adding-new-modules:
+
+Adding new modules
+------------------
 
 `LiteDRAM <https://github.com/enjoy-digital/litedram>`_ controller provides out-of-the-box support for many DRAM modules.
 Supported modules can be found in `litedram/modules.py <https://github.com/enjoy-digital/litedram/blob/master/litedram/modules.py>`_.
@@ -69,4 +74,4 @@ Adding module configuration
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 After verifying that given module configuration stored in SPD works correctly it can be used to define module in Python.
-To do that use the output of ``spd_eeprom.py show`` to add a new module as described in :ref:`adding-new-dram-modules`
+To do that use the output of ``spd_eeprom.py show`` to add a new module as described in :ref:`adding-new-modules`

--- a/doc/general.rst
+++ b/doc/general.rst
@@ -162,6 +162,8 @@ communication with the simulated device:
 
 TIP: Typing ``make ARGS="--sim"`` will cause LiteX to generate only intermediate files and stop right after that.
 
+.. _controlling-the-board:
+
 Controlling the board
 ^^^^^^^^^^^^^^^^^^^^^
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -9,7 +9,7 @@ Welcome to LiteX Row Hammer Tester!
    zcu104.rst
    zcu104_img.rst
    playbook.rst
-   development.rst
+   dram_modules.rst
 
 .. toctree::
    :maxdepth: 2

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,4 +10,5 @@ gitpython
 -e third_party/litex-boards
 # vexriscv cpu
 git+https://github.com/litex-hub/pythondata-cpu-vexriscv.git
+pexpect
 yapf

--- a/rowhammer_tester/scripts/spd_eeprom.py
+++ b/rowhammer_tester/scripts/spd_eeprom.py
@@ -37,15 +37,23 @@ def read_spd(console, spd_addr, init_commands=None):
 
 
 def parse_hexdump(string):
-    last_addr = -1
+    prev_addr = -1
+    found = False
     for line in string.split('\n'):
-        if line.strip().startswith('0x'):
-            tokens = line.strip().split()
-            addr = int(tokens[0], 16)
-            assert addr > last_addr
-            for byte in tokens[1:17]:
-                yield int(byte, 16)
-            last_addr = addr
+        # whole memory dump will be a single block of following lines
+        # find it and stop when another line is found
+        if not found and not line.strip().startswith('0x'):
+            continue
+        found = True
+        if not line.strip().startswith('0x'):
+            break
+
+        tokens = line.strip().split()
+        addr = int(tokens[0], 16)
+        assert addr > prev_addr
+        for byte in tokens[1:17]:
+            yield int(byte, 16)
+        prev_addr = addr
 
 
 def dump_object(obj, show_hidden=False, header=True):

--- a/rowhammer_tester/scripts/spd_eeprom.py
+++ b/rowhammer_tester/scripts/spd_eeprom.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python
+
+import os
+import sys
+import time
+import argparse
+
+import pexpect
+from pexpect import replwrap
+
+from litedram.modules import parse_spd_hexdump, SDRAMModule
+
+from rowhammer_tester.scripts.utils import get_generated_defs, RemoteClient, litex_server
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(os.path.realpath(__file__)))
+
+SPD_COMMANDS = {
+    # on ZCU104 first configure the I2C switch to select DDR4 SPD EEPROM, which than has base address 0b001
+    'zcu104': (1, ['i2c_write 0x74 0x80']),
+}
+
+
+def read_spd(console, spd_addr, init_commands=None):
+    assert 0 < spd_addr < 0b111, 'SPD EEPROM max address is 0b111 (defined by A0, A1, A2 pins)'
+    prompt = '^.*litex[^>]*> '  # '92;1mlitex\x1b[0m> '
+    console.sendline()
+    console.expect(prompt)
+    for cmd in init_commands or []:
+        console.sendline(cmd)
+        console.expect(prompt)
+    console.sendline('sdram_spd {}'.format(spd_addr))
+    console.expect('Memory dump:')
+    console.expect(prompt)
+    spd_data = console.after.decode()
+    return spd_data
+
+
+def parse_hexdump(string):
+    last_addr = -1
+    for line in string.split('\n'):
+        if line.strip().startswith('0x'):
+            tokens = line.strip().split()
+            addr = int(tokens[0], 16)
+            assert addr > last_addr
+            for byte in tokens[1:17]:
+                yield int(byte, 16)
+            last_addr = addr
+
+
+def dump_object(obj, show_hidden=False, header=True):
+    bold = '\033[1m'
+    clear = '\033[0m'
+    if header:
+        print('{}{}:{}'.format(bold, obj.__class__.__name__, clear))
+    d = obj if isinstance(obj, dict) else vars(obj)
+    for var, val in d.items():
+        if var == "self" or (var.startswith('_') and not show_hidden):
+            continue
+        print("  {}: {}".format(var, val))
+
+
+def show_module(spd_data, clk_freq):
+    module = SDRAMModule.from_spd_data(spd_data, clk_freq=clk_freq)
+    dump_object(module)
+    dump_object(module.__class__, header=False)
+    dump_object(module.technology_timings)
+    dump_object(module.speedgrade_timings['default'])
+    dump_object(module.geom_settings)
+    dump_object(module.timing_settings)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest='cmd')
+    read = subparsers.add_parser('read')
+    show = subparsers.add_parser('show')
+    read.add_argument('output_file', help='File to save SPD data to')
+    read.add_argument('--srv', action='store_true', help='Start litex server in background')
+    show.add_argument('input_file', help='File with SPD data')
+    read.add_argument(
+        '--mem-timeout', default=20, type=int, help='Time to wait for memory initialization')
+    show.add_argument('clk_freq', help='DRAM controller clock frequency')
+    args = parser.parse_args()
+
+    if args.cmd == 'read':
+        if args.srv:
+            litex_server()
+
+        defs = get_generated_defs()
+        target = defs['TARGET']
+        if target not in SPD_COMMANDS:
+            raise NotImplementedError('SPD commands not available for target: {}'.format(target))
+        spd_addr, init_commands = SPD_COMMANDS[target]
+
+        console = pexpect.spawn('python bios_console.py -t litex_term', cwd=SCRIPT_DIR, timeout=6)
+        wb = RemoteClient()
+        wb.open()
+        if not wb.regs.ddrctrl_init_done.read():
+            print('Wating for CPU to finish memory training ...')
+            for _ in range(int(args.mem_timeout / 0.2)):
+                time.sleep(0.2)
+                print('.', end='', flush=True)
+                if wb.regs.ddrctrl_init_done.read():
+                    break
+            print()
+            time.sleep(2)
+        wb.close()
+
+        output = read_spd(console, spd_addr, init_commands)
+        spd_data = list(parse_hexdump(output))
+
+        with open(args.output_file, 'wb') as f:
+            f.write(bytes(spd_data))
+
+    if args.cmd == 'show':
+        with open(args.input_file, 'rb') as f:
+            spd_data = f.read()
+
+        clk_freq = float(args.clk_freq)
+        module = SDRAMModule.from_spd_data(spd_data, clk_freq=clk_freq)
+        dump_object(module)
+        dump_object(module.__class__, header=False)
+        dump_object(module.technology_timings)
+        dump_object(module.speedgrade_timings['default'])
+        dump_object(module.geom_settings)
+        dump_object(module.timing_settings)

--- a/rowhammer_tester/targets/arty.py
+++ b/rowhammer_tester/targets/arty.py
@@ -75,8 +75,8 @@ class SoC(common.RowHammerSoC):
             nphases        = 4,
             sys_clk_freq   = self.sys_clk_freq)
 
-    def get_sdram_module(self, speedgrade=None):
-        return self.sdram_module_cls(self.sys_clk_freq, "1:4", speedgrade=speedgrade)
+    def get_sdram_ratio(self):
+        return "1:4"
 
     def add_host_bridge(self):
         self.submodules.ethphy = LiteEthPHYMII(

--- a/rowhammer_tester/targets/zcu104.py
+++ b/rowhammer_tester/targets/zcu104.py
@@ -222,8 +222,8 @@ class SoC(common.RowHammerSoC):
             sys_clk_freq     = self.sys_clk_freq,
             iodelay_clk_freq = 500e6)
 
-    def get_sdram_module(self, speedgrade=None):
-        return self.sdram_module_cls(self.sys_clk_freq, "1:4", speedgrade=speedgrade)
+    def get_sdram_ratio(self):
+        return "1:4"
 
     def add_host_bridge(self):
         self.add_uartbone(name="serial", clk_freq=self.sys_clk_freq, baudrate=1e6, cd="uart")

--- a/rowhammer_tester/targets/zcu104.py
+++ b/rowhammer_tester/targets/zcu104.py
@@ -10,6 +10,7 @@ from litex.soc.integration.builder import Builder
 from litex.soc.integration.soc_core import colorer
 from litex.soc.cores.clock import USMMCM, USIDELAYCTRL, AsyncResetSynchronizer
 from litex.soc.interconnect import axi, wishbone
+from litex.soc.cores.bitbang import I2CMaster
 
 from litedram.phy import usddrphy
 
@@ -165,39 +166,48 @@ class ZynqUSPS(Module):
 
 class SoC(common.RowHammerSoC):
     def __init__(self, **kwargs):
+        min_rom = 0x9000
+        if kwargs["integrated_rom_size"] < min_rom:
+            kwargs["integrated_rom_size"] = min_rom
+
         super().__init__(**kwargs)
 
+        if self.args.sim:
+            return
+
+        # SPD EEPROM I2C ---------------------------------------------------------------------------
+        self.submodules.i2c = I2CMaster(self.platform.request("i2c"))
+        self.add_csr("i2c")
+
         # ZynqUS+ PS -------------------------------------------------------------------------------
-        if not self.args.sim:
-            # Add Zynq US+ PS wrapper
-            self.submodules.ps = ZynqUSPS()
+        self.submodules.ps = ZynqUSPS()
 
-            # Configure PS->PL AXI
-            # AXI(32) -> AXILite(32) -> WishBone(32) -> SoC Interconnect
-            axi_ps = self.ps.add_axi_gp_fpd_master(data_width=32)
+        # Configure PS->PL AXI
+        # AXI(32) -> AXILite(32) -> WishBone(32) -> SoC Interconnect
+        axi_ps = self.ps.add_axi_gp_fpd_master(data_width=32)
 
-            axi_lite_ps = axi.AXILiteInterface(data_width=32, address_width=40)
-            self.submodules += axi.AXI2AXILite(axi_ps, axi_lite_ps)
+        axi_lite_ps = axi.AXILiteInterface(data_width=32, address_width=40)
+        self.submodules += axi.AXI2AXILite(axi_ps, axi_lite_ps)
 
-            # Use M_AXI_HPM0_FPD base address thaht will fit our whole address space (0x0004_0000_0000)
-            base_address = None
-            for base, size in self.ps.PS_MEMORY_MAP['gp_fpd_master'][0]:
-                if size >= 2**30-1:
-                    base_address = base
-                    break
-            assert base_address is not None
+        # Use M_AXI_HPM0_FPD base address thaht will fit our whole address space (0x0004_0000_0000)
+        base_address = None
+        for base, size in self.ps.PS_MEMORY_MAP['gp_fpd_master'][0]:
+            if size >= 2**30-1:
+                base_address = base
+                break
+        assert base_address is not None
 
-            def chunks(lst, n):
-                for i in range(0, len(lst), n):
-                    yield lst[i:i + n]
+        def chunks(lst, n):
+            for i in range(0, len(lst), n):
+                yield lst[i:i + n]
 
-            addr_str = '_'.join(chunks('{:012x}'.format(base_address), 4))
-            self.logger.info("Connecting PS AXI master from PS address {}.".format(colorer('0x' + addr_str)))
+        addr_str = '_'.join(chunks('{:012x}'.format(base_address), 4))
+        self.logger.info("Connecting PS AXI master from PS address {}.".format(colorer('0x' + addr_str)))
 
-            wb_ps = wishbone.Interface(adr_width=40-2)  # AXILite2Wishbone requires the same address widths
-            self.submodules += axi.AXILite2Wishbone(axi_lite_ps, wb_ps, base_address=base_address)
-            # silently ignores address bits above 30
-            self.bus.add_master(name='ps_axi', master=wb_ps)
+        wb_ps = wishbone.Interface(adr_width=40-2)  # AXILite2Wishbone requires the same address widths
+        self.submodules += axi.AXILite2Wishbone(axi_lite_ps, wb_ps, base_address=base_address)
+        # silently ignores address bits above 30
+        self.bus.add_master(name='ps_axi', master=wb_ps)
 
     def get_platform(self):
         return zcu104.Platform()


### PR DESCRIPTION
This PR adds support for reading SPD EEPROM on boards that use SO-DIMM DRAM modules (currently only ZCU104). SPD data is saved to a file and can then be used to calculate memory module parameters (timings/geometry). The file containing SPD data is passed using the `--form-spd` command line argument. Documentation has been updated with the instructions on how to read and use SPD data (please check `dram_modules.rst`). New python dependency is required (`pexpect`) so running `make python-deps` is required.

Currently we read SPD by sending commands on the LiteX BIOS console via UART crossover and parsing the output. This solution is sub-optimal, but currently LiteX lacks an I2C core and just uses software bitbanging. In the future we could add an I2C core to perform I2C operations using it's CSRs directly from Python.