### PR TITLE
Datacenter add I2C

### DIFF
--- a/rowhammer_tester/scripts/spd_eeprom.py
+++ b/rowhammer_tester/scripts/spd_eeprom.py
@@ -18,11 +18,12 @@ SCRIPT_DIR = os.path.dirname(os.path.abspath(os.path.realpath(__file__)))
 SPD_COMMANDS = {
     # on ZCU104 first configure the I2C switch to select DDR4 SPD EEPROM, which than has base address 0b001
     'zcu104': (1, ['i2c_write 0x74 0x80']),
+    'ddr4_datacenter_test_board': (0, None),
 }
 
 
 def read_spd(console, spd_addr, init_commands=None):
-    assert 0 < spd_addr < 0b111, 'SPD EEPROM max address is 0b111 (defined by A0, A1, A2 pins)'
+    assert 0 <= spd_addr < 0b111, 'SPD EEPROM max address is 0b111 (defined by A0, A1, A2 pins)'
     prompt = '^.*litex[^>]*> '  # '92;1mlitex\x1b[0m> '
     console.sendline()
     console.expect(prompt)

--- a/rowhammer_tester/targets/ddr4_datacenter_test_board.py
+++ b/rowhammer_tester/targets/ddr4_datacenter_test_board.py
@@ -6,6 +6,7 @@ from migen import *
 
 from litex.build.xilinx.vivado import vivado_build_args, vivado_build_argdict
 from litex.soc.integration.builder import Builder
+from litex.soc.cores.bitbang import I2CMaster
 from litex.soc.cores.clock import S7PLL, S7IDELAYCTRL
 
 from litex_boards.platforms import antmicro_datacenter_ddr4_test_board
@@ -41,6 +42,10 @@ class CRG(Module):
 class SoC(common.RowHammerSoC):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
+
+        # SPD EEPROM I2C ---------------------------------------------------------------------------
+        self.submodules.i2c = I2CMaster(self.platform.request("i2c"))
+        self.add_csr("i2c")
 
     def get_platform(self):
         return antmicro_datacenter_ddr4_test_board.Platform()


### PR DESCRIPTION
Signed-off-by: Alessandro Comodi <acomodi@antmicro.com>

This adds support to read the SPD data from the DIMMs on the datacenter board.

First the hex dump needs to be saved on a file:

```
python3 spd_eeprom.py read <output_file>
```

Than the same script can be used to show human readable values of the data
```
python3 spd_eeprom.py show <SPD data file> 100e6
```

The output of the last commands should be as follows:
```
_SDRAMModule:
  clk_freq: 100000000.0
  rate: 1:4
  speedgrade: 3200
  geom_settings: <litedram.common.GeomSettings object at 0x7f3c16fd6eb0>
  timing_settings: <litedram.common.TimingSettings object at 0x7f3c16fd6e50>
  memtype: DDR4
  nbanks: 16
  nrows: 131072
  ncols: 1024
  technology_timings: <litedram.modules._TechnologyTimings object at 0x7f3c16fd6fa0>
  speedgrade_timings: {'3200': <litedram.modules._SpeedgradeTimings object at 0x7f3c16fd6fd0>, 'default': <litedram.modules._SpeedgradeTimings object at 0x7f3c16fd6fd0>}
_TechnologyTimings:
  tREFI: {'1x': 7812.5, '2x': 3906.25, '4x': 1953.125}
  tWTR: (4, 7.5)
  tCCD: (4, 5.0)
  tRRD: (4, 4.9)
  tZQCS: (128, 80)
_SpeedgradeTimings:
  tRP: 13.75
  tRCD: 13.75
  tWR: 15.0
  tRFC: {'1x': (None, 350.0), '2x': (None, 260.0), '4x': (None, 160.0)}
  tFAW: (16, 10.0)
  tRAS: 32.0
GeomSettings:
  bankbits: 4
  rowbits: 17
  colbits: 10
  addressbits: 17
TimingSettings:
  tRP: 3
  tRCD: 3
  tWR: 3
  tWTR: 2
  tREFI: 782
  tRFC: 36
  tFAW: 4
  tCCD: 2
  tRRD: 2
  tRC: 6
  tRAS: 4
  tZQCS: 32
  fine_refresh_mode: 1x

```